### PR TITLE
Remove description and URL labels in the panel selection

### DIFF
--- a/app/assets/scripts/components/indicator.js
+++ b/app/assets/scripts/components/indicator.js
@@ -126,12 +126,7 @@ const Indicator = React.createClass({
             { Error }
             <section className='layer-block layer-info'>
               <h2 className='layer-block__title layer-info__title'>Info</h2>
-              <dl className='layer-info__details'>
-                <dt>Description</dt>
-                <dd>{description}</dd>
-                <dt>Source URL</dt>
-                <dd><a href={url.resolve(config.dataHubURL, '/dataset/' + datasetName)} title='Visit data source URL' className='url'>{url.resolve(config.dataHubURL, '/dataset/' + datasetName)}</a></dd>
-              </dl>
+              <p className='layer-info__details'>{description} - <a href={url.resolve(config.dataHubURL, '/dataset/' + datasetName)} title='Visit data source URL' className='url'>view the source data</a></p>
             </section>
           </div>
         </article>

--- a/app/assets/styles/content/_p-explore-control-panel.scss
+++ b/app/assets/styles/content/_p-explore-control-panel.scss
@@ -432,10 +432,11 @@
 
 .layer-info__details {
   @extend .clearfix;
+  font-size: 0.75rem;
+  line-height: 1rem;
+
   dt, dd {
     float: left;
-    font-size: 0.75rem;
-    line-height: 1rem;
     padding-bottom: $global-spacing / 4;
   }
 
@@ -455,11 +456,5 @@
 
   a, a:visited {
     color: tint($primary-color, 48%);
-  }
-
-  .url {
-    @extend .truncated;
-    display: block;
-    width: 100%;
   }
 }


### PR DESCRIPTION
Make better use of the space available in the indicator section of the left panel.

From: 
![image](https://cloud.githubusercontent.com/assets/751330/19245383/ca6e9800-8eee-11e6-8ea1-3aa0e0abd35d.png)

To:
![image](https://cloud.githubusercontent.com/assets/751330/19245392/d98c9166-8eee-11e6-93b4-a3a597d23956.png)
