### PR TITLE
Fetch both name and description from resource

### DIFF
--- a/app/assets/scripts/components/indicator.js
+++ b/app/assets/scripts/components/indicator.js
@@ -23,7 +23,7 @@ const Indicator = React.createClass({
   },
 
   render: function () {
-    const { id, datasetName, description, editing, options, filter, visible, error } = this.props.layer
+    const { id, name, description, datasetID, editing, options, filter, visible, error } = this.props.layer
     const { updateLayerFilter } = this.props
 
     let Editor
@@ -41,7 +41,7 @@ const Indicator = React.createClass({
             />
             <div className='legend'>
             {options.value.stops.slice(0, -1).map((stop, j) => {
-              const baseColor = getLayerColor(datasetName)
+              const baseColor = getLayerColor(name)
               return <div className='legend-swath' key={stop} style={{
                 backgroundColor: chroma(baseColor).darken(j - Math.floor(options.value.stops.length / 2)).hex(),
                 width: `${(100 / (options.value.stops.length - 1)).toFixed(2)}%`
@@ -91,9 +91,9 @@ const Indicator = React.createClass({
       <li className='layer-list__layer-wrapper'>
         <article className={c('layer', {'layer--expanded': editing})}>
           <header className='layer__header'>
-            <span className='layer__legend-color' style={{background: getLayerColor(datasetName)}}></span>
+            <span className='layer__legend-color' style={{background: getLayerColor(name)}}></span>
             <div className='layer__headline'>
-              <h1 className='layer__title'>{prettifyString(datasetName)}</h1>
+              <h1 className='layer__title'>{prettifyString(name)}</h1>
               <p className='layer__summary'>{filterSummary(options, filter) + (id === popLayer.id ? '  ppl/km2' : '')}</p>
             </div>
             <div className='layer__actions'>
@@ -126,7 +126,7 @@ const Indicator = React.createClass({
             { Error }
             <section className='layer-block layer-info'>
               <h2 className='layer-block__title layer-info__title'>Info</h2>
-              <p className='layer-info__details'>{description} - <a href={url.resolve(config.dataHubURL, '/dataset/' + datasetName)} title='Visit data source URL' className='url'>view the source data</a></p>
+              <p className='layer-info__details'>{description} - <a href={url.resolve(config.dataHubURL, '/dataset/' + datasetID)} title='Visit data source URL' className='url' target="_blank">view the source data</a></p>
             </section>
           </div>
         </article>

--- a/app/assets/scripts/fetch-layers.js
+++ b/app/assets/scripts/fetch-layers.js
@@ -18,7 +18,7 @@ const metadataKeys = [
   'source',
   'url',
   'tilejson',
-  'datasetName'
+  'datasetID'
 ]
 
 export default function fetchLayers () { return fetchLayersThunk }
@@ -86,8 +86,8 @@ function fetchLayersThunk (dispatch, getState) {
         // NOTE: only use the first resource
         dataset.resources.slice(0, 1).forEach(function (resource) {
           resource.extras = (resource.extras || []).concat(dataset.extras)
-          resource.source = dataset.url
-          resource.datasetName = dataset.name
+          resource.datasetID = dataset.id
+          resource.name = resource.name
           // use dataset-wide metadata as defaults
           defaultsDeep(resource, pick(dataset, metadataKeys))
           resources.push(resource)

--- a/app/assets/scripts/utils.js
+++ b/app/assets/scripts/utils.js
@@ -117,7 +117,7 @@ export function stopsToNoUiSliderRange (stops) {
 }
 
 export function createDataPaintObject (layer) {
-  const baseColor = getLayerColor(layer.datasetName)
+  const baseColor = getLayerColor(layer.name)
   if (layer.options.value.type === 'range') {
     return {
       'fill-color': {
@@ -138,7 +138,7 @@ export function createDataPaintObject (layer) {
 
 export function createOutlinePaintObject (layer) {
   return {
-    'line-color': getLayerColor(layer.datasetName),
+    'line-color': getLayerColor(layer.name),
     'line-width': 1,
     'line-opacity': 1
   }
@@ -148,12 +148,12 @@ export function createTempPaintStyle (layer) {
   switch (layer.options.geometry.type) {
     case 'line':
       return {
-        'line-color': getLayerColor(layer.datasetName),
+        'line-color': getLayerColor(layer.name),
         'line-opacity': 1
       }
     case 'circle':
       return {
-        'circle-color': getLayerColor(layer.datasetName),
+        'circle-color': getLayerColor(layer.name),
         'circle-opacity': 1
       }
     default:
@@ -161,12 +161,12 @@ export function createTempPaintStyle (layer) {
   }
 }
 
-export function getLayerColor (datasetName) {
+export function getLayerColor (name) {
   let returnColor
-  if (presetLayerColors.hasOwnProperty(datasetName)) {
-    returnColor = presetLayerColors[datasetName]
+  if (presetLayerColors.hasOwnProperty(name)) {
+    returnColor = presetLayerColors[name]
   } else {
-    returnColor = tocolor(datasetName)
+    returnColor = tocolor(name)
       .replace('rgba(', '').split(',').map(a => Number(a)).filter(Boolean)
   }
   return chroma(returnColor).hex()
@@ -309,12 +309,12 @@ export function downloadMapPDF (props) {
   const indicators = props.layers.indicators.filter(a => a.visible)
   indicators.forEach((layer, index) => {
     doc.circle(margin + 3, 96 + mapHeight + 112 + 3 + (index * 24), 3)
-       .fill(getLayerColor(layer.datasetName))
+       .fill(getLayerColor(layer.name))
 
     doc.fontSize(8)
     doc.fillColor(secondaryFontColor)
        .font(MSLight)
-       .text(prettifyString(layer.datasetName).toUpperCase(), margin + 10, 96 + mapHeight + 112 - 2 + (index * 24))
+       .text(prettifyString(layer.name).toUpperCase(), margin + 10, 96 + mapHeight + 112 - 2 + (index * 24))
 
     doc.fontSize(8)
     doc.fillColor(baseFontColor)


### PR DESCRIPTION
Currently, a layer name is determined from the `dataset`, while the description is determined from the `resource`. This PR makes that both name and description are fetched from the resource.
