### PR TITLE
Fetch both name and description from dataset

### DIFF
--- a/app/assets/scripts/components/indicator.js
+++ b/app/assets/scripts/components/indicator.js
@@ -23,7 +23,7 @@ const Indicator = React.createClass({
   },
 
   render: function () {
-    const { id, datasetName, description, editing, options, filter, visible, error } = this.props.layer
+    const { id, datasetName, datasetNotes, editing, options, filter, visible, error } = this.props.layer
     const { updateLayerFilter } = this.props
 
     let Editor
@@ -126,7 +126,7 @@ const Indicator = React.createClass({
             { Error }
             <section className='layer-block layer-info'>
               <h2 className='layer-block__title layer-info__title'>Info</h2>
-              <p className='layer-info__details'>{description} - <a href={url.resolve(config.dataHubURL, '/dataset/' + datasetName)} title='Visit data source URL' className='url'>view the source data</a></p>
+              <p className='layer-info__details'>{datasetNotes} - <a href={url.resolve(config.dataHubURL, '/dataset/' + datasetName)} title='Visit data source URL' className='url'>view the source data</a></p>
             </section>
           </div>
         </article>

--- a/app/assets/scripts/fetch-layers.js
+++ b/app/assets/scripts/fetch-layers.js
@@ -18,7 +18,8 @@ const metadataKeys = [
   'source',
   'url',
   'tilejson',
-  'datasetName'
+  'datasetName',
+  'datasetNotes'
 ]
 
 export default function fetchLayers () { return fetchLayersThunk }
@@ -87,6 +88,7 @@ function fetchLayersThunk (dispatch, getState) {
         dataset.resources.slice(0, 1).forEach(function (resource) {
           resource.extras = (resource.extras || []).concat(dataset.extras)
           resource.source = dataset.url
+          resource.datasetNotes = dataset.notes
           resource.datasetName = dataset.name
           // use dataset-wide metadata as defaults
           defaultsDeep(resource, pick(dataset, metadataKeys))


### PR DESCRIPTION
Currently, a layer name is determined from the dataset, while the description is determined from the resource. This PR makes that both name and description are fetched from the dataset.
