### PR TITLE
Replace NaN with more human friendly text

### DIFF
--- a/app/assets/scripts/utils.js
+++ b/app/assets/scripts/utils.js
@@ -345,11 +345,11 @@ export function downloadMapPDF (props) {
   const hhCount = population / countries[props.country].avg_hh_size
   const outputs = [
     { name: 'Area', value: numberWithCommas(Math.round(area(geojson) / 1000000)) + ' KM2' },
-    { name: 'Population', value: shortenNumber(Math.round(population), 2) },
-    { name: 'Households', value: shortenNumber(hhCount, 2) },
+    { name: 'Population', value: shortenNumber(Math.round(population), 2) || 'not calculated' },
+    { name: 'Households', value: shortenNumber(hhCount, 2) || 'not calculated' },
     { name: 'Market Captured', value: Math.round(marketCapture * 100) + '%' },
     { name: 'Avg. revenue per household', value: '$' + revenuePerHousehold },
-    { name: 'Revenue estimate', value: shortenNumber(hhCount * revenuePerHousehold * marketCapture, 2) }
+    { name: 'Revenue estimate', value: shortenNumber(hhCount * revenuePerHousehold * marketCapture, 2) || 'not calculated' }
   ]
   outputs.forEach((output, index) => {
     doc.fontSize(8)


### PR DESCRIPTION
When a user doesn't hit 'Calculate Population', the resulting PDF won't have those numbers.

---

There may be a more elegant solution @drewbo 